### PR TITLE
Remove trailing comma

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "description": "A path to a folder containing EIPs and ERCs repositories",
       "type": "directory",
       "required": true,
-      "title": "Folder with EIPs and ERCs repos",
+      "title": "Folder with EIPs and ERCs repos"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
Trailing comma prevents `npm install` from running with `npm ERR! JSON.parse Unexpected token } in JSON at position 706 while parsing near '...nd ERCs repos",`