### PR TITLE
Add output flag to `ray build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typescript": "^5.2.2"
   },
   "scripts": {
-    "build": "ray build -e dist",
+    "build": "ray build -e dist -o dist",
     "dev": "ray develop",
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",


### PR DESCRIPTION
Thanks for the extension! I've noticed that the build command doesn't actually save the build files in a `dist` directory unless the `-o` (`--output`) flag is added with argument `dist`. This PR does just that.